### PR TITLE
feat: support set constraints decompose.

### DIFF
--- a/include/lala/logic/algorithm.hpp
+++ b/include/lala/logic/algorithm.hpp
@@ -1065,7 +1065,7 @@ std::optional<F> decompose_set_constraints(const F& f, std::map<std::string, std
 
   //TODO check using implications S \subeq T where S and T are both sets S = {1, 2} and T = {1, 2, 3}. Both S and T have already been decomposed to set variables
   // __S_contains__1 = true => __T_contains_1 = true AND __S_contains_2 = true => __T_contains_2 = true
-  if(f.is_binary() && f.sig() == SUBSETEQ && f.seq(0).is(F::S) && f.seq(1).is(F::S)) {
+  if(f.is_binary() && f.sig() == SUBSETEQ) {
     auto left = f.seq(0).lv().data();
     auto right = f.seq(1).lv().data();
 
@@ -1074,19 +1074,19 @@ std::optional<F> decompose_set_constraints(const F& f, std::map<std::string, std
       typename F::Sequence conjunction(alloc);
       auto booleanVars = set2bool_vars[left];
       for (auto& boolVar : booleanVars) {
+        auto rightBoolVar = boolVar;
         size_t pos = boolVar.find_last_of('_'); 
         long long int z = std::stoi(boolVar.substr(pos + 1));
         conjunction.push_back(
           F::make_binary(
             F::make_binary(F::make_lvar(f.type(), LVar<typename F::allocator_type>(boolVar)), EQ, F::make_bool(true, f.type()),f.type()),
             IMPLY,
-            F::make_binary(F::make_lvar(f.type(), LVar<typename F::allocator_type>(boolVar.replace(boolVar.find(left), std::string(left).size(), right))), EQ, F::make_bool(true, f.type()),f.type())
+            F::make_binary(F::make_lvar(f.type(), LVar<typename F::allocator_type>(rightBoolVar.replace(rightBoolVar.find(left), std::string(left).size(), right))), EQ, F::make_bool(true, f.type()),f.type())
           )
         );
       }
       return F::make_nary(AND, std::move(conjunction), f.type());
     }
-
   }
   return f;
 }

--- a/include/lala/logic/algorithm.hpp
+++ b/include/lala/logic/algorithm.hpp
@@ -1014,7 +1014,7 @@ std::optional<F> decompose_set_constraints(const F& f, std::map<std::string, std
       return F::make_nary(AND, std::move(conjunction), f.type());
     }
   }
-  //TODO for test3 now I can only be able to generate sth like this:
+  // TODO: for test3 now I can only be able to generate sth like this:
   // `x = 1 => __S_contains_1 = true`.
     // F::make_binary(
     //   F::make_binary(F::make_lvar(f.type(), LVar<typename F::allocator_type>("x")), EQ, F::make_z(1, f.type()),f.type()),

--- a/include/lala/logic/algorithm.hpp
+++ b/include/lala/logic/algorithm.hpp
@@ -1062,11 +1062,6 @@ std::optional<F> decompose_set_constraints(const F& f, std::map<std::string, std
     }
     return F::make_nary(AND, std::move(conjunction), f.type());
   }
-    // F::make_binary(
-    //   F::make_binary(F::make_lvar(f.type(), LVar<typename F::allocator_type>("x")), EQ, F::make_z(1, f.type()),f.type()),
-    //   IMPLY,
-    //   F::make_binary(F::make_lvar(f.type(), LVar<typename F::allocator_type>("__S_contains_1")), EQ, F::make_bool(true, f.type()),f.type())
-    // );
   return f;
 }
 

--- a/include/lala/logic/algorithm.hpp
+++ b/include/lala/logic/algorithm.hpp
@@ -1062,6 +1062,32 @@ std::optional<F> decompose_set_constraints(const F& f, std::map<std::string, std
     }
     return F::make_nary(AND, std::move(conjunction), f.type());
   }
+
+  //TODO check using implications S \subeq T where S and T are both sets S = {1, 2} and T = {1, 2, 3}. Both S and T have already been decomposed to set variables
+  // __S_contains__1 = true => __T_contains_1 = true AND __S_contains_2 = true => __T_contains_2 = true
+  if(f.is_binary() && f.sig() == SUBSETEQ && f.seq(0).is(F::S) && f.seq(1).is(F::S)) {
+    auto left = f.seq(0).lv().data();
+    auto right = f.seq(1).lv().data();
+
+    if (!set2bool_vars[left].empty()) {
+      typename F::allocator_type alloc;
+      typename F::Sequence conjunction(alloc);
+      auto booleanVars = set2bool_vars[left];
+      for (auto& boolVar : booleanVars) {
+        size_t pos = boolVar.find_last_of('_'); 
+        long long int z = std::stoi(boolVar.substr(pos + 1));
+        conjunction.push_back(
+          F::make_binary(
+            F::make_binary(F::make_lvar(f.type(), LVar<typename F::allocator_type>(boolVar)), EQ, F::make_bool(true, f.type()),f.type()),
+            IMPLY,
+            F::make_binary(F::make_lvar(f.type(), LVar<typename F::allocator_type>(boolVar.replace(boolVar.find(left), std::string(left).size(), right))), EQ, F::make_bool(true, f.type()),f.type())
+          )
+        );
+      }
+      return F::make_nary(AND, std::move(conjunction), f.type());
+    }
+
+  }
   return f;
 }
 

--- a/include/lala/logic/algorithm.hpp
+++ b/include/lala/logic/algorithm.hpp
@@ -1062,9 +1062,8 @@ std::optional<F> decompose_set_constraints(const F& f, std::map<std::string, std
     }
     return F::make_nary(AND, std::move(conjunction), f.type());
   }
-
-  //TODO check using implications S \subeq T where S and T are both sets S = {1, 2} and T = {1, 2, 3}. Both S and T have already been decomposed to set variables
-  // __S_contains__1 = true => __T_contains_1 = true AND __S_contains_2 = true => __T_contains_2 = true
+  
+  // decompose subeq
   if(f.is_binary() && f.sig() == SUBSETEQ) {
     auto left = f.seq(0).lv().data();
     auto right = f.seq(1).lv().data();

--- a/include/lala/logic/algorithm.hpp
+++ b/include/lala/logic/algorithm.hpp
@@ -979,43 +979,89 @@ CUDA F decompose_arith_neq_constraint(const F& f, const typename F::allocator_ty
  */
 template <class F>
 std::optional<F> decompose_set_constraints(const F& f, std::map<std::string, std::vector<std::string>>& set2bool_vars) {
-  if (f.is_binary() && f.sig() == AND && f.seq(1).is_binary() && f.seq(1).seq(1).is(F::S)) {
+  // ground truth, if formula is an existential
+  if (f.is(F::E)) {
+    const auto& [lv, sort] = f.exists();
+    if (sort.is_set()) {
+      return {};
+    } 
+    return f;
+  }
+  // decompose var in set constraint
+  if (f.is_binary() && f.sig() == IN && f.seq(1).is(F::S)) {
     typename F::allocator_type alloc;
+    typename F::Sequence conjunction(alloc);
+    auto var = f.seq(0).lv().data();
     auto varNameBase = std::string("__")
-              + f.seq(1).seq(0).lv().data()
+              + var
               + "_contains_";
 
-    const auto& set = f.seq(1).seq(1).s();
-    const auto& [_, u] = set[0];
-    if (u.s().size() == 1) {
-      const auto& [uu, ll] = u.s()[0];
-      auto varName1 = varNameBase + std::to_string(uu.z());
-      if (uu == ll) {
-        return F::make_exists(f.type(), LVar<typename F::allocator_type>(varName1), Sort<typename F::allocator_type>::Bool);
+    const auto& set = f.seq(1).s();
+    // lb seems always "{}", so omit it.
+    const auto& [__, ub] = set[0];
+
+    for (size_t i = 0; i < ub.s().size(); ++i) {
+      const auto& [llb, uub] = ub.s()[i];
+      // only manage "set of integers"
+      if (llb.is(F::Z) && uub.is(F::Z)) {
+        // use [llb, uub) to replace [llb, uub] to handle with edge cases llb == uub.
+        for (long long int j = llb.z(); j < (uub.z() + 1); ++j) {
+          auto varName = varNameBase + (j < 0 ? "m" + std::to_string(-j) : std::to_string(j));
+          conjunction.push_back(
+              F::make_exists(f.type(), LVar<typename F::allocator_type>(varName), Sort<typename F::allocator_type>::Bool)
+          );
+          // write boolean to set map
+          set2bool_vars[var].push_back(varName);
+        }
       }
-      auto varName2 = varNameBase + std::to_string(ll.z());
-      return
-        F::make_binary(
-          F::make_exists(f.type(), LVar<typename F::allocator_type>(varName1), Sort<typename F::allocator_type>::Bool),
-          AND,
-          F::make_exists(f.type(), LVar<typename F::allocator_type>(varName2), Sort<typename F::allocator_type>::Bool),
-          f.type(),
-        alloc);
-    } else {
+    }
+    if (conjunction.size() == 0) {
+      return {};
+    }
+    return F::make_nary(AND, std::move(conjunction), f.type());
+  }
+  // handle set variable
+  if (f.is_binary() && f.sig() == IN && f.seq(1).is(F::LV)) {
+    // get variable name
+    auto var = f.seq(1).lv().data();
+    
+    if (!set2bool_vars[var].empty()) {
+      typename F::allocator_type alloc;
       typename F::Sequence conjunction(alloc);
-      conjunction.reserve(u.s().size());
-      for (size_t i = 0; i < u.s().size(); ++i) {
-        const auto& [uu, __] = u.s()[i]; 
-        auto varName = varNameBase + (uu.z() < 0 ? "m" + std::to_string(-uu.z()) : std::to_string(uu.z()));
+      auto booleanVars = set2bool_vars[var];
+      for (auto& boolVar : booleanVars) {
+        size_t pos = boolVar.find_last_of('_'); 
+        long long int z = std::stoi(boolVar.substr(pos + 1));
         conjunction.push_back(
-            F::make_exists(f.type(), LVar<typename F::allocator_type>(varName), Sort<typename F::allocator_type>::Bool)
+          F::make_binary(
+            F::make_binary(f.seq(0), EQ, F::make_z(z, f.type()),f.type()),
+            IMPLY,
+            F::make_binary(F::make_lvar(f.type(), LVar<typename F::allocator_type>(boolVar)), EQ, F::make_bool(true, f.type()),f.type())
+          )
         );
       }
       return F::make_nary(AND, std::move(conjunction), f.type());
     }
+    return {};
   }
-  // TODO: for test3 now I can only be able to generate sth like this:
-  // `x = 1 => __S_contains_1 = true`.
+  // decompose AND sequences
+  if (f.is(F::Seq) && f.sig() == AND) {
+    typename F::allocator_type alloc;
+    typename F::Sequence conjunction(alloc);
+    conjunction.reserve(f.seq().size());
+    for (size_t i = 0; i < f.seq().size(); ++i) {
+      auto subf = decompose_set_constraints(f.seq(i), set2bool_vars);
+      if (subf.has_value()) {
+        conjunction.push_back(
+          subf.value()
+        );
+      }
+    }
+    if (conjunction.size() == 0) {
+      return {};
+    }
+    return F::make_nary(AND, std::move(conjunction), f.type());
+  }
     // F::make_binary(
     //   F::make_binary(F::make_lvar(f.type(), LVar<typename F::allocator_type>("x")), EQ, F::make_z(1, f.type()),f.type()),
     //   IMPLY,

--- a/tests/src/algorithm_test.cpp
+++ b/tests/src/algorithm_test.cpp
@@ -5,7 +5,6 @@
 #include "lala/logic/logic.hpp"
 #include <gtest/gtest.h>
 
-
 #include <optional>
 
 using namespace lala;
@@ -74,8 +73,12 @@ TEST(AST, SetRewritingMembership1) {
      var bool: __S_contains_2;\
      constraint bool_imply(int_eq(x, 1), bool_eq(__S_contains_1, true));\
      constraint bool_imply(int_eq(x, 2), bool_eq(__S_contains_2, true));");
-  /** NOTE: `bool_imply(int_eq(x, 1), bool_eq(__S_contains_1, true))` represents
-   * the implication constraint: `x = 1 => __S_contains_1 = true`.
+  /** NOTE: `bool_imply(int_eq(x, 1), bool_eq(__S_contains_1, true))`
+   *
+   * represents
+   * the implication constraint: `x = 1 => __S_contains_1 =
+   *
+   * true`.
    */
 }
 
@@ -103,7 +106,21 @@ TEST(AST, SetRewritingMembership2) {
      constraint bool_imply(int_eq(x, 11), bool_eq(__S_contains_11, true));\
      constraint bool_imply(int_eq(x, 12), bool_eq(__S_contains_12, true));\
      constraint bool_imply(int_eq(x, 13), bool_eq(__S_contains_13, true));");
-  /** NOTE: `bool_imply(int_eq(x, 1), bool_eq(__S_contains_1, true))` represents
-   * the implication constraint: `x = 1 => __S_contains_1 = true`.
+  /** NOTE: `bool_imply(int_eq(x, 1), bool_eq(__S_contains_1, true))`
+   *
+   * represents
+   * the implication constraint: `x = 1 => __S_contains_1 =
+   *
+   * true`.
    */
+}
+
+TEST(AST, SetRewritingCardinality1) {
+  test_rewriting("var set of 1..2: S;\
+    constraint set_card(S, 1);",
+
+                 "var bool: __S_contains_1;\
+     var bool: __S_contains_2;\
+     constraint bool_imply(true, int_plus(__S_contains_1, __S_contains_2, 1));");
+
 }

--- a/tests/src/algorithm_test.cpp
+++ b/tests/src/algorithm_test.cpp
@@ -40,7 +40,21 @@ TEST(AST, SetRewritingDomain2) {
    );
  }
 
-TEST(AST, SetRewritingMembership) {
+TEST(AST, SetRewritingDomain3) {
+  test_rewriting(
+    "var set of -3..3: S;",
+
+    "var bool: __S_contains_m3;\
+     var bool: __S_contains_m2;\
+     var bool: __S_contains_m1;\
+     var bool: __S_contains_0;\
+     var bool: __S_contains_1;\
+     var bool: __S_contains_2;\
+     var bool: __S_contains_3;"
+  );
+}
+
+TEST(AST, SetRewritingMembership1) {
   test_rewriting(
     "var int: x;\
      var set of {1, 2}: S;\
@@ -57,3 +71,33 @@ TEST(AST, SetRewritingMembership) {
    */
 }
 
+TEST(AST, SetRewritingMembership2) {
+  test_rewriting(
+    "var int: x;\
+     var set of {1, 2, 4, 5, 6, 9, 11, 12, 13}: S;\
+     constraint set_in(x, S);",
+
+    "var int: x;\
+     var bool: __S_contains_1;\
+     var bool: __S_contains_2;\
+     var bool: __S_contains_4;\
+     var bool: __S_contains_5;\
+     var bool: __S_contains_6;\
+     var bool: __S_contains_9;\
+     var bool: __S_contains_11;\
+     var bool: __S_contains_12;\
+     var bool: __S_contains_13;\
+     constraint bool_imply(int_eq(x, 1), bool_eq(__S_contains_1, true));\
+     constraint bool_imply(int_eq(x, 2), bool_eq(__S_contains_2, true));\
+     constraint bool_imply(int_eq(x, 4), bool_eq(__S_contains_4, true));\
+     constraint bool_imply(int_eq(x, 5), bool_eq(__S_contains_5, true));\
+     constraint bool_imply(int_eq(x, 6), bool_eq(__S_contains_6, true));\
+     constraint bool_imply(int_eq(x, 9), bool_eq(__S_contains_9, true));\
+     constraint bool_imply(int_eq(x, 11), bool_eq(__S_contains_11, true));\
+     constraint bool_imply(int_eq(x, 12), bool_eq(__S_contains_12, true));\
+     constraint bool_imply(int_eq(x, 13), bool_eq(__S_contains_13, true));"
+  );
+  /** NOTE: `bool_imply(int_eq(x, 1), bool_eq(__S_contains_1, true))` represents the implication constraint:
+   * `x = 1 => __S_contains_1 = true`.
+   */
+}

--- a/tests/src/algorithm_test.cpp
+++ b/tests/src/algorithm_test.cpp
@@ -17,9 +17,6 @@ void test_rewriting(const char* input, const char* expected, bool can_rewrite = 
   auto rewritten = decompose_set_constraints(*f, set2bool_vars);
   EXPECT_EQ(rewritten.has_value(), can_rewrite);
   auto expect = parse_flatzinc_str<standard_allocator>(expected);
-  expect->print();
-  printf("\n");
-  rewritten->print();
   EXPECT_TRUE(expect);
   EXPECT_EQ(*rewritten, *expect);
 }

--- a/tests/src/algorithm_test.cpp
+++ b/tests/src/algorithm_test.cpp
@@ -17,6 +17,9 @@ void test_rewriting(const char* input, const char* expected, bool can_rewrite = 
   auto rewritten = decompose_set_constraints(*f, set2bool_vars);
   EXPECT_EQ(rewritten.has_value(), can_rewrite);
   auto expect = parse_flatzinc_str<standard_allocator>(expected);
+  expect->print();
+  printf("\n");
+  rewritten->print();
   EXPECT_TRUE(expect);
   EXPECT_EQ(*rewritten, *expect);
 }
@@ -30,30 +33,30 @@ TEST(AST, SetRewritingDomain1) {
   );
 }
 
-// TEST(AST, SetRewritingDomain2) {
-//   test_rewriting(
-//     "var set of {-1, 1, 3}: S;",
+TEST(AST, SetRewritingDomain2) {
+  test_rewriting(
+      "var set of {-1, 1, 3}: S;",
 
-//     "var bool: __S_contains_m1;\
-//      var bool: __S_contains_1;\
-//      var bool: __S_contains_3;"
-//   );
-// }
+      "var bool: __S_contains_m1;\
+      var bool: __S_contains_1;\
+      var bool: __S_contains_3;"
+   );
+ }
 
-// TEST(AST, SetRewritingMembership) {
-//   test_rewriting(
-//     "var int: x;\
-//      var set of {1, 2}: S;\
-//      constraint set_in(x, S);",
+TEST(AST, SetRewritingMembership) {
+  test_rewriting(
+    "var int: x;\
+     var set of {1, 2}: S;\
+     constraint set_in(x, S);",
 
-//     "var int: x;\
-//      var bool: __S_contains_1;\
-//      var bool: __S_contains_2;\
-//      constraint bool_imply(int_eq(x, 1), bool_eq(__S_contains_1, true));\
-//      constraint bool_imply(int_eq(x, 2), bool_eq(__S_contains_2, true));"
-//   );
-//   /** NOTE: `bool_imply(int_eq(x, 1), bool_eq(__S_contains_1, true))` represents the implication constraint:
-//    * `x = 1 => __S_contains_1 = true`.
-//    */
-// }
+    "var int: x;\
+     var bool: __S_contains_1;\
+     var bool: __S_contains_2;\
+     constraint bool_imply(int_eq(x, 1), bool_eq(__S_contains_1, true));\
+     constraint bool_imply(int_eq(x, 2), bool_eq(__S_contains_2, true));"
+  );
+  /** NOTE: `bool_imply(int_eq(x, 1), bool_eq(__S_contains_1, true))` represents the implication constraint:
+   * `x = 1 => __S_contains_1 = true`.
+   */
+}
 

--- a/tests/src/algorithm_test.cpp
+++ b/tests/src/algorithm_test.cpp
@@ -54,6 +54,22 @@ TEST(AST, SetRewritingDomain3) {
   );
 }
 
+TEST(AST, SetRewritingSubseteq) {
+  test_rewriting(
+    "var set of {1, 2}: S;\
+     var set of {1, 2, 3}: T;\
+     constraint set_subset(S, T);",
+
+    "var bool: __S_contains_1;\
+     var bool: __S_contains_2;\
+     var bool: __T_contains_1;\
+     var bool: __T_contains_2;\
+     var bool: __T_contains_3;\
+     constraint bool_imply(bool_eq(__S_contains_1, true), bool_eq(__T_contains_1, true));\
+     constraint bool_imply(bool_eq(__S_contains_2, true), bool_eq(__T_contains_2, true));"
+  );
+}
+
 TEST(AST, SetRewritingMembership1) {
   test_rewriting(
     "var int: x;\


### PR DESCRIPTION
## test cases
- [x] test 1
- [x] test 2
- [x] test 3
- [x] test 4
- [x] test 5
- [x] test 6 

## Tasks
### Set
TBA
### Subset 
TBA
### Set In
TBA
### Set Cardinality 
#### Formal Definition

Let $\( U = \{v_1, v_2, \dots, v_n\} \)$ be a finite universe,  and for each $\( v_i \in U \)$, define a Boolean indicator:

$b_i  \overset{\text{def}}{=}  \left[ v_i \in S \right] \quad\text{for } i = 1,\dots,n$

Then, the cardinality of the set $\( S \)$ satisfies:

$|S| = k \quad \Longleftrightarrow \quad \sum_{i=1}^n b_i = k$

#### Decomposition

We decompose flatzinc constraint with approach like this:

```
var set of 1..2: S;
constraint set_card(S, 1);
```

With set card constraint above, decomposition functionality will generate:

```
var bool: __S_contains_1;
var bool: __S_contains_2;
constraint bool_imply(true, int_plus(__S_contains_1, __S_contains_2, 1));
``` 



